### PR TITLE
Add npm + eyeglass support.

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -1,0 +1,1 @@
+@import '_text-stroke';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Text stroke polyfill for Sass.",
   "main": "_text-stroke.scss",
   "directories": {
-   "example": "example"
+    "example": "example"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "sass-text-stroke",
+  "version": "1.0.0",
+  "description": "Text stroke polyfill for Sass.",
+  "main": "_text-stroke.scss",
+  "directories": {
+   "example": "example"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hudochenkov/sass-text-stroke.git"
+  },
+  "keywords": [
+    "eyeglass-module",
+    "sass",
+    "text",
+    "stroke",
+    "outline",
+    "shadow"
+  ],
+  "eyeglass": {
+    "sassDir": "./",
+    "needs": "*",
+    "exports": false
+  },
+  "author": "Aleks Hudochenkov <aleks@hudochenkov.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/hudochenkov/sass-text-stroke/issues"
+  },
+  "homepage": "https://github.com/hudochenkov/sass-text-stroke#readme"
+}


### PR DESCRIPTION
This PR adds npm + eyeglass package support.
License is not clear, hence MIT license was assumed in npm package metadata.